### PR TITLE
Add help text based on readme

### DIFF
--- a/BackupMod/deps/FilUnderscore/Manifest.xml
+++ b/BackupMod/deps/FilUnderscore/Manifest.xml
@@ -1,5 +1,5 @@
 <ModManifest>
   <ManifestUrl>https://raw.githubusercontent.com/ntaklive/BackupMod/master/BackupMod/deps/FilUnderscore/Manifest.xml</ManifestUrl>
-  <Version>2.1.0</Version>
+  <Version>2.1.1</Version>
   <GameVersion ReleaseType="Alpha" Major="20" Minor="6" Build="9" />
 </ModManifest>

--- a/BackupMod/deps/common/ModInfo.xml
+++ b/BackupMod/deps/common/ModInfo.xml
@@ -4,7 +4,7 @@
         <Name value="Backup mod"/>
         <Description value="This modlet makes it possible to automatically backup your game saves"/>
         <Author value="ntaklive"/>
-        <Version value="2.1.0"/>
+        <Version value="2.1.1"/>
         <Website value="https://github.com/ntaklive/BackupMod" />
     </ModInfo>
 </xml>

--- a/BackupMod/src/Modules/Commands/ConsoleCmdBackup.cs
+++ b/BackupMod/src/Modules/Commands/ConsoleCmdBackup.cs
@@ -23,6 +23,7 @@ public partial class ConsoleCmdBackup : ConsoleCmdBase
     private readonly IWorldInfoService _worldInfoService;
     [CanBeNull] private readonly IChatService _chatService;
     private readonly ILogger<ConsoleCmdBackup> _logger;
+    private readonly string HelpText;
 
     public ConsoleCmdBackup()
     {
@@ -31,6 +32,19 @@ public partial class ConsoleCmdBackup : ConsoleCmdBase
         _worldInfoService = Provider.GetRequiredService<IWorldInfoService>();
         _chatService = Provider.GetService<IChatService>();
         _logger = Provider.GetRequiredService<ILogger<ConsoleCmdBackup>>();
+
+        Dictionary<string, string> dict = new()
+        {
+            { "", "perform a forceful backup" },
+            { "info", "show the current configuration of the mod" },
+            { "list", "show all available backups" },
+            { "restore", "restore a save from a backup" },
+            { "delete", "delete a backup" },
+            { "start", "start an AutoBackup process (even if disabled in settings.json)" },
+            { "stop", "stop the current AutoBackup process" },
+        };
+        int i = 1; int j = 1;
+        HelpText = $"Usage:\n  {string.Join("\n  ", dict.Keys.Select(command => $"{i++}. {GetCommands()[0]} {command}").ToList())}\nDescription Overview\n{string.Join("\n", dict.Values.Select(description => $"{j++}. {description}").ToList())}";
     }
     
     public override bool IsExecuteOnClient => false;
@@ -45,6 +59,8 @@ public partial class ConsoleCmdBackup : ConsoleCmdBase
 
     public override string GetDescription() =>
         "Some commands to simplify the creation of backups (commands are provided by BackupMod)";
+
+    public override string GetHelp() => HelpText;
 
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     public override async void Execute(List<string> _params, CommandSenderInfo _senderInfo)


### PR DESCRIPTION
Close #4 

This update provides help output in the console when running `help bp` or `help backup`:

## Before
```
help bp
2022-09-28T09:22:09 1138.844 INF Executing command 'help bp' by Telnet from 127.0.0.1:35912
*** Command: bp ***
No detailed help available.
Description: Some commands to simplify the creation of backups (commands are provided by BackupMod)
```
```
version
Game version: Alpha 20.6 (b8) Compatibility Version: Alpha 20.6
Mod Backup mod: 2.1.0
```

## After
```
help bp
*** Command: bp ***
Usage:
  1. backup
  2. backup info
  3. backup list
  4. backup restore
  5. backup delete
  6. backup start
  7. backup stop
Description Overview
1. perform a forceful backup
2. show the current configuration of the mod
3. show all available backups
4. restore a save from a backup
5. delete a backup
6. start an AutoBackup process (even if disabled in settings.json)
7. stop the current AutoBackup process
```
```
version
Game version: Alpha 20.6 (b8) Compatibility Version: Alpha 20.6
Mod Backup mod: 2.1.1
```

## Unchanged
```
help * bp
*** List of Commands for "bp" ***
 backup bp => Some commands to simplify the creation of backups (commands are provided by BackupMod)
```